### PR TITLE
docs: document acceptance tests and guard the test/acc target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -80,5 +80,12 @@ test/docs:
 test/pkg:
 	go test ./pkg/... -v -coverprofile=cover.out $(TESTARGS) -timeout 60m
 
+# Acceptance tests run against a REAL pfSense instance and create/destroy live
+# config. Set TF_PFSENSE_URL, TF_PFSENSE_USERNAME and TF_PFSENSE_PASSWORD first.
+# Run a subset with TESTARGS, e.g.:
+#   make test/acc TESTARGS='-run TestAccFirewallNATNPt'
 test/acc:
+ifndef TF_PFSENSE_PASSWORD
+	$(error TF_PFSENSE_PASSWORD must be set. Acceptance tests run against a real pfSense instance — also set TF_PFSENSE_URL and TF_PFSENSE_USERNAME (see README "Running Acceptance Tests"))
+endif
 	TF_ACC=1 TFENV_TERRAFORM_VERSION=$(TERRAFORM_VERSION) go test ./internal/provider/... -v -coverprofile=cover.out $(TESTARGS) -timeout 60m

--- a/README.md
+++ b/README.md
@@ -257,9 +257,36 @@ go vet ./...
 # Generate documentation
 make docs
 
-# Run acceptance tests (requires a pfSense instance)
-make test/acc
+# Unit tests (no pfSense instance required)
+make test/pkg
 ```
+
+### Running Acceptance Tests
+
+Acceptance tests exercise the provider against a **real pfSense instance** by
+creating, importing, updating and destroying live configuration. Only run them
+against a non-production/lab firewall.
+
+Each resource's acceptance tests live in `internal/provider/*_test.go` and use a
+`CheckDestroy` to confirm resources are removed from pfSense afterwards.
+
+Set the connection environment variables, then run `make test/acc`:
+
+```shell
+export TF_PFSENSE_URL="https://192.168.1.1"   # your lab pfSense
+export TF_PFSENSE_USERNAME="admin"
+export TF_PFSENSE_PASSWORD="..."
+
+# Run the full acceptance suite
+make test/acc
+
+# Run a single resource's tests
+make test/acc TESTARGS='-run TestAccFirewallNATNPt'
+```
+
+> The `test/acc` target sets `TF_ACC=1` for you and fails fast if
+> `TF_PFSENSE_PASSWORD` is not set. Without `TF_ACC`, acceptance tests are
+> skipped, so `go test ./...` remains safe to run anywhere (this is what CI does).
 
 ## License
 


### PR DESCRIPTION
## Summary
Makes the existing acceptance-test workflow discoverable and safer to run locally (no CI runner required).

- **README — new "Running Acceptance Tests" section:** documents the required `TF_PFSENSE_URL` / `TF_PFSENSE_USERNAME` / `TF_PFSENSE_PASSWORD` env vars, how to run a single resource's tests via `TESTARGS` (e.g. `make test/acc TESTARGS='-run TestAccFirewallNATNPt'`), and a safety note that acceptance tests create/destroy live config on a real pfSense.
- **GNUmakefile — `test/acc` guard:** fails fast with a helpful message when `TF_PFSENSE_PASSWORD` is unset, and documents `TESTARGS` inline.

Acceptance tests still skip automatically without `TF_ACC`, so `go test ./...` (what CI runs) remains safe everywhere. A self-hosted CI runner against a live pfSense remains a future option on the roadmap.

## Testing
- `make -n test/acc` errors clearly when the password is unset; passes the guard when set.
